### PR TITLE
Add filename parameter to configureLogger function

### DIFF
--- a/example/file_logging.py
+++ b/example/file_logging.py
@@ -1,0 +1,30 @@
+"""Example demonstrating file logging with happy_python_logging."""
+
+import logging
+import os
+from happy_python_logging.app import configureLogger
+
+# Configure a logger that writes to a file
+log_file = "app.log"
+logger = configureLogger(
+    "file_example",
+    level=logging.DEBUG,
+    format="%(asctime)s | %(levelname)s | %(name)s - %(message)s",
+    filename=log_file,
+)
+
+# Log some messages
+logger.debug("This is a debug message")
+logger.info("This is an info message")
+logger.warning("This is a warning message")
+logger.error("This is an error message")
+
+# Show that the log file was created
+print(f"Log file created at: {os.path.abspath(log_file)}")
+print("Log file contents:")
+with open(log_file, "r") as f:
+    print(f.read())
+
+# Clean up
+os.remove(log_file)
+print("Log file removed.")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,7 @@
 import logging
+import os
 import sys
+import tempfile
 
 from happy_python_logging.app import configureLogger
 
@@ -7,6 +9,11 @@ from happy_python_logging.app import configureLogger
 def assert_console_handler(actual: logging.Handler) -> None:
     assert isinstance(actual, logging.StreamHandler)
     assert actual.stream is sys.stderr
+
+
+def assert_file_handler(actual: logging.Handler, expected_filename: str) -> None:
+    assert isinstance(actual, logging.FileHandler)
+    assert actual.baseFilename == os.path.abspath(expected_filename)
 
 
 def assert_formatter(actual: logging.Formatter, expected_format: str) -> None:
@@ -22,3 +29,31 @@ def test_basicConfigForLogger():
     assert len(actual.handlers) == 1
     assert_console_handler(actual.handlers[0])
     assert_formatter(actual.handlers[0].formatter, "%(message)s")
+
+
+def test_configureLogger_with_filename():
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        temp_filename = temp_file.name
+
+    try:
+        actual = configureLogger(
+            "awesome_file", level=logging.INFO, format="%(levelname)s: %(message)s", filename=temp_filename
+        )
+
+        assert actual.level == logging.INFO
+        assert len(actual.handlers) == 1
+        assert_file_handler(actual.handlers[0], temp_filename)
+        assert_formatter(actual.handlers[0].formatter, "%(levelname)s: %(message)s")
+
+        # Test that logging actually works
+        test_message = "Test log message to file"
+        actual.info(test_message)
+
+        with open(temp_filename, "r") as f:
+            log_content = f.read()
+            assert f"INFO: {test_message}" in log_content
+
+    finally:
+        # Clean up the temporary file
+        if os.path.exists(temp_filename):
+            os.unlink(temp_filename)


### PR DESCRIPTION
## 変更内容

`happy_python_logging.app.configureLogger()` に `filename` パラメータを追加しました。

- `filename` パラメータが指定された場合、ロガーのハンドラはそのファイルに出力します
- `filename` パラメータが指定されていない場合、ロガーのハンドラは（これまで通り）標準エラー出力に出力します

## 実装詳細

1. `LoggerConfiguration` TypedDictに `filename` パラメータを追加
2. `configureLogger` 関数を更新して `filename` パラメータを処理するように変更
3. ファイルロギング機能のテストを追加
4. ファイルロギングを示すサンプルコードを追加

すべてのテストが正常に通過することを確認済みです。

これにより、Issue #1 が解決されます。