### PR TITLE
feat: Add NotFilter that inverts a wrapped filter

### DIFF
--- a/src/happy_python_logging/lib/filters.py
+++ b/src/happy_python_logging/lib/filters.py
@@ -1,4 +1,9 @@
 import logging
+from typing import Protocol
+
+
+class _Filterer(Protocol):
+    def filter(self, record: logging.LogRecord) -> bool: ...
 
 
 class OrFilter:
@@ -25,3 +30,11 @@ class OrFilter:
             msg = "Cannot combine OrFilter with a logging.Filter that has an empty name"
             raise ValueError(msg)
         return OrFilter(other.name, *self.prefixes)
+
+
+class NotFilter:
+    def __init__(self, filter: _Filterer) -> None:
+        self.filter_ = filter
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return not self.filter_.filter(record)

--- a/src/happy_python_logging/lib/filters.py
+++ b/src/happy_python_logging/lib/filters.py
@@ -1,9 +1,12 @@
 import logging
-from typing import Protocol
+from typing import Callable, Protocol, Union
 
 
 class _Filterer(Protocol):
     def filter(self, record: logging.LogRecord) -> bool: ...
+
+
+_FilterLike = Union[_Filterer, Callable[[logging.LogRecord], bool]]
 
 
 class OrFilter:
@@ -33,8 +36,14 @@ class OrFilter:
 
 
 class NotFilter:
-    def __init__(self, filter: _Filterer) -> None:
+    def __init__(self, filter: _FilterLike) -> None:
         self.filter_ = filter
 
     def filter(self, record: logging.LogRecord) -> bool:
-        return not self.filter_.filter(record)
+        # Mirror logging.Filterer.filter dispatch: objects with a filter()
+        # method use it, otherwise the filter is a callable taking the record.
+        if hasattr(self.filter_, "filter"):
+            result = self.filter_.filter(record)
+        else:
+            result = self.filter_(record)
+        return not result

--- a/tests/lib/test_filters.py
+++ b/tests/lib/test_filters.py
@@ -119,6 +119,16 @@ class TestNotFilter:
         assert combined.filter(logging.makeLogRecord({"name": "ham"}))
         assert combined.filter(logging.makeLogRecord({"name": "quux"}))
 
+    def test_wraps_callable_filter(self):
+        # logging accepts callables as filters, so NotFilter must too
+        combined = NotFilter(lambda record: record.name != "spam")
+
+        # The callable passes non-"spam", so NotFilter rejects them
+        assert not combined.filter(logging.makeLogRecord({"name": "ham"}))
+        assert not combined.filter(logging.makeLogRecord({"name": "other"}))
+        # The callable rejects "spam", so NotFilter passes it
+        assert combined.filter(logging.makeLogRecord({"name": "spam"}))
+
     def test_double_negation(self):
         # NotFilter(NotFilter(...)) restores the original behavior
         combined = NotFilter(NotFilter(logging.Filter("spam")))

--- a/tests/lib/test_filters.py
+++ b/tests/lib/test_filters.py
@@ -2,7 +2,7 @@ import logging
 
 import pytest
 
-from happy_python_logging.lib.filters import OrFilter
+from happy_python_logging.lib.filters import NotFilter, OrFilter
 
 
 class TestOrFilter:
@@ -87,4 +87,42 @@ class TestOrFilter:
         assert combined.filter(logging.makeLogRecord({"name": "lib1.module"}))
         assert combined.filter(logging.makeLogRecord({"name": "app"}))
         assert combined.filter(logging.makeLogRecord({"name": "service.api"}))
+        assert not combined.filter(logging.makeLogRecord({"name": "other"}))
+
+
+class TestNotFilter:
+    @pytest.fixture
+    def handler_under_test(self):
+        # Invert a standard logging.Filter
+        return NotFilter(logging.Filter("spam"))
+
+    @pytest.mark.parametrize("name", ["other", "ham", "foo.spam"])
+    def test_pass(self, name, handler_under_test):
+        # logging.Filter("spam") rejects these, so NotFilter passes them
+        record = logging.makeLogRecord({"name": name})
+        assert handler_under_test.filter(record)
+
+    @pytest.mark.parametrize("name", ["spam", "spam.eggs"])
+    def test_reject(self, name, handler_under_test):
+        # logging.Filter("spam") passes these, so NotFilter rejects them
+        record = logging.makeLogRecord({"name": name})
+        assert not handler_under_test.filter(record)
+
+    def test_wraps_or_filter(self):
+        # NotFilter can wrap an OrFilter (duck-typed, not a logging.Filter)
+        combined = NotFilter(OrFilter("spam", "ham.egg"))
+
+        # Names OrFilter would pass are now rejected
+        assert not combined.filter(logging.makeLogRecord({"name": "spam"}))
+        assert not combined.filter(logging.makeLogRecord({"name": "ham.egg"}))
+        # Names OrFilter would reject are now passed
+        assert combined.filter(logging.makeLogRecord({"name": "ham"}))
+        assert combined.filter(logging.makeLogRecord({"name": "quux"}))
+
+    def test_double_negation(self):
+        # NotFilter(NotFilter(...)) restores the original behavior
+        combined = NotFilter(NotFilter(logging.Filter("spam")))
+
+        assert combined.filter(logging.makeLogRecord({"name": "spam"}))
+        assert combined.filter(logging.makeLogRecord({"name": "spam.eggs"}))
         assert not combined.filter(logging.makeLogRecord({"name": "other"}))

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,72 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "flake8"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "happy-python-logging"
+source = { editable = "." }
+dependencies = [
+    { name = "typing-extensions" },
+]
+
+[package.optional-dependencies]
+flake8 = [
+    { name = "flake8" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "flake8", marker = "extra == 'flake8'" },
+    { name = "typing-extensions" },
+]
+provides-extras = ["flake8"]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## Context

`src/happy_python_logging/lib/filters.py` には `OrFilter` だけがあった。補集合を表現するための `NotFilter` を追加する。

## What

`NotFilter(filter)` はフィルタ的オブジェクトを1つ受け取り、ラップしたフィルタの `filter()` が返す真偽値を反転する。

- 引数は `isinstance(logging.Filter)` で実行時に縛らず、`typing.Protocol`（`_Filterer`）による構造的型ヒントにした。
- これにより標準の `logging.Filter` だけでなく、`OrFilter` のようなダックタイプや `NotFilter(NotFilter(...))` のネストも自然に合成できる。
- インスタンス属性は `filter()` メソッドとの衝突を避けるため `self.filter_`（末尾アンダースコア）。

## Tests

`tests/lib/test_filters.py` に `TestNotFilter` を追加（既存 `TestOrFilter` と同じスタイル）。

- 標準 `logging.Filter` の反転（pass/reject）
- `OrFilter` を包む合成
- 二重否定

`pytest tests/lib/test_filters.py` 全20件 green。Codex review 指摘なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)